### PR TITLE
Limit kill to minecraft only

### DIFF
--- a/mc
+++ b/mc
@@ -41,7 +41,7 @@ mchammer ()
   exit
  fi
 done
-kill $(pgrep java)
+kill $(ps -e -o pid,command | awk '$2 ~ "awk" {next}; $0 ~ "minecraft" {print $1}')
 }
 
 # dow: 0=Sun 1=Mon 2=Tue 3=Wed 4=Thu (-le=less than or equal to) &&=And


### PR DESCRIPTION
This way it will only kill processes with "minecraft" in their command line and ignore any other java programs (ex. Eclipse IDE, which may be used for a programming class).

Broken down:
 - ps prints the process id and command line for all processes
 - this gets piped to awk, which outputs the pids for any process (except awk itself) with the string "minecraft" anywhere in the command used to start it
 - kill then kills those processes

I tested this on Linux Mint 19.1 with the latest game and launcher versions.
The reason for formatting ps output with "-o pid,command" is in case of a username containing minecraft, otherwise ps would output the user and awk would match it, killing all processes owned by that user.